### PR TITLE
Fix for issue #6 right icon alignment incorrect on smaller screens.

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -3,8 +3,8 @@
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand mr-auto" href="#">
-      <img class="d.d-inline-block align-text-top" id="camel-logo" alt="Github Logo" src="/assets/zflyingcamel.gif" width="40" />
+    <a class="navbar-brand me-auto" href="#">
+      <img class="d.d-inline-block align-text-top" id="camel-logo" alt="CamelBird Logo" src="/assets/zflyingcamel.gif" width="40" />
       {{ title }}.com
     </a>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -14,7 +14,7 @@
         <li class="nav-item"><a class="nav-link" routerLink="/interests" routerLinkActive="active">Interests</a></li>
       </ul>
     </div>
-    <div class="ml-auto hidden-sm-up">
+    <div class="camelbird-navbar-right">
       <a aria-label="Github link" target="_blank" rel="noopener" href="https://github.com/dangard" title="Github">
         <img id="github-logo" alt="Github Logo" src="/assets/GitHub-Mark-Light-32px.png" height="24" />
       </a>

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -23,6 +23,12 @@ nav.navbar {
     opacity: 0.8;
   }
 
+  .camelbird-navbar-right {
+    position: absolute;
+    right: 10px;
+    top: 15px;
+  }
+
   ul {
     li {
       a.nav-link {


### PR DESCRIPTION
## Description
The right icons in the menu were showing up in the bottom of the hamburger menu in the collapsed nav when they should stay at the right end of the navbar at all breakpoints.